### PR TITLE
Remove whitespace on period string

### DIFF
--- a/iso8601.js
+++ b/iso8601.js
@@ -141,8 +141,8 @@
         var overflowLimits     = [0, 12, 4, 7, 24, 60, 60];
         var struct;
 
-        // upcase the string just in case people don't follow the letter of the law
-        period = period.toUpperCase();
+        // upcase and clear whitespace on the string just in case people don't follow the letter of the law
+        period = period.toUpperCase().trim();
 
         // input validation
         if (!period)                         return duration;


### PR DESCRIPTION
While parsing the WMS 1.3.0 example spec: http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xml

The period field includes some trailing newlines and whitespace which was causing the parse operation to fail.